### PR TITLE
always sort by start date, omit deleted and templates

### DIFF
--- a/src/services/calendarEventService.ts
+++ b/src/services/calendarEventService.ts
@@ -37,6 +37,9 @@ export async function getAllCalendarEvents(
   // Sort by start date
   query.orderBy('starts', 'asc')
 
+  // Delete deleted events and templates
+  query.where('deleted', '0').where('template', '0')
+
   if (fromDate) {
     query.where(
       'starts',

--- a/src/services/calendarEventService.ts
+++ b/src/services/calendarEventService.ts
@@ -33,14 +33,16 @@ export async function getAllCalendarEvents(
   fromDate: string
 ): Promise<CalendarEvent[]> {
   const query = db('calendar_events').select()
+
+  // Sort by start date
+  query.orderBy('starts', 'asc')
+
   if (fromDate) {
-    query
-      .where(
-        'starts',
-        '>=',
-        moment(new Date(fromDate)).format('YYYY.MM.DD HH:mm')
-      )
-      .orderBy('starts', 'asc')
+    query.where(
+      'starts',
+      '>=',
+      moment(new Date(fromDate)).format('YYYY.MM.DD HH:mm')
+    )
   }
   return query.then(R.map(parseQueryResult))
 }


### PR DESCRIPTION
d5bf9eb moves sorting functionality from behind the fromDate check to the start. this might affect performance by a tiny amount.

db0a19a omits deleted and template events from being returned while not modifying the returned object as to not break existing applications. this simply makes `deleted` checking redundant on applications relying on event-api.

for future development:
- do we want to still offer templates to some applications?
    - can this be done from a seperate endpoint, e.g. `/api/templates`?
- do we want to still offer deleted events?
    - if an event was deleted, we can be fairly certain it is not meant to be exposed