### PR TITLE
fix date representation in returned json

### DIFF
--- a/src/services/calendarEventService.ts
+++ b/src/services/calendarEventService.ts
@@ -25,6 +25,12 @@ const db = knex({
     user: process.env.DB_USER,
     password: process.env.DB_PASSWORD,
     database: process.env.DB_NAME,
+    typeCast: (field, next) => {
+      if (field.type === 'DATETIME') {
+        return field.string()?.replace(' ', 'T') ?? null
+      }
+      return next()
+    },
   },
   client: 'mysql2',
 })


### PR DESCRIPTION
This fixes a problem where timezones are returned from the API
with "Z" at the end of them, causing them to always be parsed
by end-user libraries as UTC time.

Currently this is not a problem if the end user is also in the UTC
timezone, but otherwise it will cause the time to drift by the
offset from UTC the user is currently in.

For example, eventbird would have started reporting incorrect times
if it was ever moved away from AWS.

(This will cause `created` to lose timezone infomation, but this
_should be the case_. If we weant `created` to be a moment with
timezone information, it should be a `TIMESTAMP` and not a `DATETIME`.)