### PR TITLE
Migrations in general, end time field for calendar_events

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ COPY yarn.lock ./
 COPY package.json ./
 COPY tsconfig.json ./
 COPY src ./src
+COPY knexfile.ts ./
 RUN yarn
 
 RUN yarn build

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ COPY package.json ./
 COPY tsconfig.json ./
 COPY src ./src
 COPY knexfile.ts ./
+COPY migrations ./migrations
+
 RUN yarn
 
 RUN yarn build

--- a/knexfile.ts
+++ b/knexfile.ts
@@ -1,0 +1,29 @@
+import type { Knex } from 'knex'
+
+if (!process.env.DB_URL) {
+  throw new Error('DB_URL is not defined')
+}
+
+const DB_URL = new URL(process.env.DB_URL)
+
+export const config: Record<string, Knex.Config> = {
+  production: {
+    client: 'mysql2',
+    connection: {
+      host: DB_URL.hostname,
+      port: Number(DB_URL.port),
+      user: DB_URL.username,
+      password: DB_URL.password,
+      database: DB_URL.pathname.slice(1),
+      typeCast: (field: any, next: () => unknown) => {
+        if (field.type === 'DATETIME') {
+          return field.string()?.replace(' ', 'T') ?? null
+        }
+        return next()
+      },
+    },
+    migrations: {
+      tableName: 'knex_migrations',
+    },
+  },
+}

--- a/knexfile.ts
+++ b/knexfile.ts
@@ -6,7 +6,7 @@ if (!process.env.DB_URL) {
 
 const DB_URL = new URL(process.env.DB_URL)
 
-export const config: Record<string, Knex.Config> = {
+const config: { [key: string]: Knex.Config } = {
   production: {
     client: 'mysql2',
     connection: {
@@ -15,7 +15,7 @@ export const config: Record<string, Knex.Config> = {
       user: DB_URL.username,
       password: DB_URL.password,
       database: DB_URL.pathname.slice(1),
-      typeCast: (field: any, next: () => unknown) => {
+      typeCast: (field, next) => {
         if (field.type === 'DATETIME') {
           return field.string()?.replace(' ', 'T') ?? null
         }
@@ -23,7 +23,10 @@ export const config: Record<string, Knex.Config> = {
       },
     },
     migrations: {
-      tableName: 'knex_migrations',
+      tableName: 'knex_migrations_events',
     },
   },
 }
+
+module.exports = config
+export default config

--- a/migrations/20240923124619_add_end_time.ts
+++ b/migrations/20240923124619_add_end_time.ts
@@ -1,0 +1,27 @@
+import type { Knex } from 'knex'
+
+/**
+ * Up: Add a new column `ends` to the `calendar_events` table after the `starts` column
+ */
+export async function up(knex: Knex): Promise<void> {
+  const hasColumn = await knex.schema.hasColumn('calendar_events', 'ends')
+
+  if (!hasColumn) {
+    await knex.schema.table('calendar_events', table => {
+      table.datetime('ends').nullable().after('starts')
+    })
+  }
+}
+
+/**
+ * Down: Drop the `ends` column from the `calendar_events` table
+ */
+export async function down(knex: Knex): Promise<void> {
+  const hasColumn = await knex.schema.hasColumn('calendar_events', 'ends')
+
+  if (hasColumn) {
+    await knex.schema.table('calendar_events', table => {
+      table.dropColumn('ends')
+    })
+  }
+}

--- a/package.json
+++ b/package.json
@@ -26,5 +26,6 @@
     "start": "node ./dist/App.js",
     "start-dev": "ts-node ./src/App.ts",
     "build": "tsc"
-  }
+  },
+  "packageManager": "yarn@1.22.19"
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "scripts": {
     "start": "node ./dist/App.js",
     "start-dev": "ts-node ./src/App.ts",
-    "build": "tsc"
+    "build": "tsc",
+    "migrate": "knex migrate:latest"
   },
   "packageManager": "yarn@1.22.19"
 }

--- a/src/services/calendarEventService.ts
+++ b/src/services/calendarEventService.ts
@@ -1,5 +1,5 @@
 import knex from 'knex'
-import { config } from '../../knexfile'
+import config from '../../knexfile'
 import { pick } from 'remeda'
 import moment from 'moment'
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,8 @@
 
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es6",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
-    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    "target": "es6" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+    "module": "NodeNext" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
@@ -14,7 +14,7 @@
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    "outDir": "./dist",                        /* Redirect output structure to the directory. */
+    "outDir": "./dist" /* Redirect output structure to the directory. */,
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                     /* Enable project compilation */
     // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
@@ -25,8 +25,8 @@
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
 
     /* Strict Type-Checking Options */
-    "strict": true,                           /* Enable all strict type-checking options. */
-    "noImplicitAny": false,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    "strict": true /* Enable all strict type-checking options. */,
+    "noImplicitAny": false /* Raise error on expressions and declarations with an implied 'any' type. */,
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
@@ -41,14 +41,14 @@
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 
     /* Module Resolution Options */
-    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "nodenext" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
     // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
 
@@ -63,7 +63,7 @@
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
 
     /* Advanced Options */
-    "skipLibCheck": true,                     /* Skip type checking of declaration files. */
-    "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
+    "skipLibCheck": true /* Skip type checking of declaration files. */,
+    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   }
 }


### PR DESCRIPTION
Adds migration capability for calendar_events as a first step to events-microservice managing calendar events. This also means we don't have to add migration capability to member service (cumbersome and won't be maintained for long, hopefully).

Will require a PR to k8s configuration to run migration script as an initContainer step